### PR TITLE
Add a wait for availability of master server

### DIFF
--- a/5.7/core/init-slave.sh
+++ b/5.7/core/init-slave.sh
@@ -67,9 +67,6 @@ echo mysqldump completed.
 echo Starting slave ...
 mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "START SLAVE;"
 
-echo Initial health check:
-check_slave_health
-
 echo "Waiting for health grace period ($REPLICATION_HEALTH_GRACE_PERIOD seconds) and slave to be still healthy:"
 sleep $REPLICATION_HEALTH_GRACE_PERIOD
 

--- a/5.7/core/init-slave.sh
+++ b/5.7/core/init-slave.sh
@@ -34,6 +34,11 @@ done
 echo "MySQL Master ($MASTER_HOST) is available!"
 
 
+if [[ -n "${REPLICATION_START_DELAY}" ]] ; then
+  echo "Waiting $REPLICATION_START_DELAY s before starting replication"
+  sleep $REPLICATION_START_DELAY
+fi
+
 echo Updating master connection info in slave.
 
 mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "RESET MASTER; \

--- a/5.7/core/init-slave.sh
+++ b/5.7/core/init-slave.sh
@@ -27,9 +27,11 @@ until mysqladmin ping \
   --protocol=TCP \
   --connect-timeout 3 --silent ;
 do
-  echo "MySQL Master is unavailable - sleeping"
+  echo "MySQL Master ($MASTER_HOST) is unavailable - sleeping"
   sleep 1
 done
+
+echo "MySQL Master ($MASTER_HOST) is available!"
 
 
 echo Updating master connetion info in slave.

--- a/5.7/core/init-slave.sh
+++ b/5.7/core/init-slave.sh
@@ -21,6 +21,16 @@ check_slave_health () {
   return 0
 }
 
+until mysqladmin ping \
+  -h "$MASTER_HOST" \
+  --port=$MASTER_PORT \
+  --protocol=TCP \
+  --connect-timeout 3 --silent ;
+do
+  echo "MySQL Master is unavailable - sleeping"
+  sleep 1
+done
+
 
 echo Updating master connetion info in slave.
 

--- a/5.7/core/init-slave.sh
+++ b/5.7/core/init-slave.sh
@@ -15,7 +15,7 @@ check_slave_health () {
   if ! echo "$status" | grep -qs "Slave_IO_Running: Yes"    ||
      ! echo "$status" | grep -qs "Slave_SQL_Running: Yes"   ||
      ! echo "$status" | grep -qs "Seconds_Behind_Master: 0" ; then
-	echo WARNING: Replication is not healthy.
+  echo WARNING: Replication is not healthy.
     return 1
   fi
   return 0
@@ -34,7 +34,7 @@ done
 echo "MySQL Master ($MASTER_HOST) is available!"
 
 
-echo Updating master connetion info in slave.
+echo Updating master connection info in slave.
 
 mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "RESET MASTER; \
   CHANGE MASTER TO \
@@ -65,14 +65,14 @@ mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "START SLAVE;"
 echo Initial health check:
 check_slave_health
 
-echo Waiting for health grace period and slave to be still healthy:
+echo "Waiting for health grace period ($REPLICATION_HEALTH_GRACE_PERIOD seconds) and slave to be still healthy:"
 sleep $REPLICATION_HEALTH_GRACE_PERIOD
 
 counter=0
 while ! check_slave_health; do
   if (( counter >= $REPLICATION_HEALTH_TIMEOUT )); then
-    echo ERROR: Replication not healthy, health timeout reached, failing.
-	break
+    echo "ERROR: Replication not healthy, health timeout of $REPLICATION_HEALTH_TIMEOUT seconds reached, failing."
+  break
     exit 1
   fi
   let counter=counter+1

--- a/5.7/core/replication-entrypoint.sh
+++ b/5.7/core/replication-entrypoint.sh
@@ -43,7 +43,7 @@ mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "\
 EOF
 else
   # TODO: make server-id discoverable
-  export SERVER_ID=2
+  [ -z "$SERVER_ID" ] && export SERVER_ID=2
   cp -v /init-slave.sh /docker-entrypoint-initdb.d/
   cat > /etc/mysql/mysql.conf.d/repl-slave.cnf << EOF
 [mysqld]


### PR DESCRIPTION
I was finding in my testing that often my slave container would start initialising replication before my master container was ready. This usually resulted in the slave getting into a bad state and having to be reset. 

This code snippet executes a MySQL ping until the master is ready, then proceeds to setup replication on the slave.